### PR TITLE
feat: Implement support for multiple DNS record types

### DIFF
--- a/pkg/core/options/options.go
+++ b/pkg/core/options/options.go
@@ -7,6 +7,7 @@ import (
 	"github.com/boy-hack/ksubdomain/v2/pkg/core/gologger"
 	"github.com/boy-hack/ksubdomain/v2/pkg/runner/outputter"
 	"github.com/boy-hack/ksubdomain/v2/pkg/runner/processbar"
+	"github.com/google/gopacket/layers" // Added for layers.DNSType
 )
 
 type OptionMethod string
@@ -31,8 +32,12 @@ type Options struct {
 	SpecialResolvers   map[string][]string // 可针对特定域名使用的dns resolvers
 	WildcardFilterMode string              // 泛解析过滤模式: "basic", "advanced", "none"
 	WildIps            []string
-	Predict            bool // 是否开启预测模式
+	Predict            bool                 // 是否开启预测模式
+	QueryTypes         []layers.DNSType     // DNS查询类型列表
 }
+
+// DefaultQueryTypes Ksubdomain默认查询的DNS类型
+var DefaultQueryTypes = []layers.DNSType{layers.DNSTypeA}
 
 func Band2Rate(bandWith string) int64 {
 	suffix := string(bandWith[len(bandWith)-1])
@@ -80,5 +85,12 @@ func GetResolvers(resolvers []string) []string {
 func (opt *Options) Check() {
 	if opt.Silent {
 		gologger.MaxLevel = gologger.Silent
+	}
+	if opt.QueryTypes == nil || len(opt.QueryTypes) == 0 {
+		// This case should ideally be handled by the default value in flag definition
+		// or ensure parseQueryTypes always returns a default if input is empty post-flag parsing.
+		// For safety, we can still set a default here.
+		opt.QueryTypes = DefaultQueryTypes
+		gologger.Infof("QueryTypes is empty, using default value: A\n")
 	}
 }

--- a/pkg/runner/statusdb/db.go
+++ b/pkg/runner/statusdb/db.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/google/gopacket/layers" // Added for layers.DNSType
 )
 
 type Item struct {
@@ -13,6 +15,7 @@ type Item struct {
 	Time        time.Time // 发送时间
 	Retry       int       // 重试次数
 	DomainLevel int       // 域名层级
+	QueryType   layers.DNSType // DNS查询类型
 }
 
 // StatusDb 使用分片锁实现的高性能状态数据库


### PR DESCRIPTION
This commit introduces the capability to query for multiple DNS record types during subdomain enumeration.

Key changes include:

- Added a `-qtype` (alias `-qt`) CLI flag to the 'enum' command, allowing you to specify a comma-separated list of desired record types (e.g., "A,AAAA,MX,TXT,NS,CNAME,SOA,PTR"). Defaults to "A".
- Updated the internal options and status database to handle and track queries for different record types distinctly.
- Modified the packet sending logic to dispatch DNS queries for each specified type per domain.
- Enhanced the packet receiving logic to correctly associate responses with their specific query type and domain, preventing premature status updates.
- Significantly improved the `dnsRecord2String` function to provide detailed and correctly formatted string representations for A, AAAA, NS, CNAME, PTR, TXT, MX, and SOA records.
- Adjusted the retry mechanism to re-queue the base domain for all configured query types if a specific domain:type query times out.

This enhancement makes KSubdomain a more versatile DNS reconnaissance tool, allowing you to gather richer information about discovered subdomains.